### PR TITLE
fixed 'dir' variable check in bindings transform example.

### DIFF
--- a/developer-guide/building-apps/managing-data/building-data-driven-apps.md
+++ b/developer-guide/building-apps/managing-data/building-data-driven-apps.md
@@ -182,9 +182,9 @@ in which the binding is firing:
 
 ```javascript
     {from: "$.slider.value", to: "$.input.value", oneWay:false, transform: function(val, dir) {
-        if (dir == "source") {
+        if (dir == 1) { //source (`from`) setting value for target (`to`)
             return (val * 100) + "%";
-        } else {
+        } else if (dir == 2) { //target (`to`) setting value for source (`from`)
             return parseInt(val) / 100;
         }
     }}


### PR DESCRIPTION
The article "Building Data-Driven Apps" has an example for using assigning a transform function to a two way binding. In the example the function checks the `dir` variable for the value "source". However it appears that the value that is passed to the `dir` variable is actually +1 and +2 as opposed to "source" and "target". 