### PR TITLE
set the jsdoc version to a fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "grunt": "~0.4.5",
     "grunt-contrib-less": "~0.11.4",
     "grunt-shell": "^1.1.1",
-    "jsdoc": "^3.3.0-alpha13"
+    "jsdoc": "3.3.0-alpha13"
   }
 }


### PR DESCRIPTION
Issue.

When generating docs, most everything is being marked private. 

Fix.

When Enyo Docs were developed, we used JSDOC 3.3.0-alpha13 , I removed the carrot from the version line, so ensure 3.3.0-alpha13 is installed so docs generate properly.